### PR TITLE
Fix code examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,8 @@ Output:
 <time>3/26/2014</time>
 ```
 
-> **Note**: Timestamps are _only_ supported as numeric values, using a String representation of a timestamp will fail. This is no shortcoming of the Dust helper, but of JavaScript's Date constructor:
+> **Note**: Timestamps are always numeric values, passing them as String will fail (see JavaScript Date constructor).
 
-> ```js
-(new Date("1395872439650")).getTime();
-// => NaN
-```
 
 ####Formatting the output
 Template:


### PR DESCRIPTION
1. Change variable name in example from 'dateString' to 'dateStr' to match
   other occurrences
2. Dust helper parameters (like locale or currency identifiers) must be passed
   as strings. Numeric values like 40000.004 should be passed as strings as
   well, otherwise decimals with leading zeros get truncated (e.g. 40000.4).
