### PR TITLE
Improve browser bundling with Browserify/Webpack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,7 +54,7 @@ module.exports = function (grunt) {
                 options: {
                     prelude: [
                         '// GENERATED FILE',
-                        'var DustIntl = require("./helpers");\n\n'
+                        'var DustIntl = require("./dust-intl");\n\n'
                     ].join('\n'),
 
                     wrapEntry: function (entry) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 /* jshint node:true */
 'use strict';
 
-// Add all locale data to `DustIntl`.
+// Add all locale data to `DustIntl`. This module will be ignored when bundling
+// for the browser with Browserify/Webpack.
 require('./lib/locales');
 
-exports = module.exports = require('./lib/helpers');
+exports = module.exports = require('./lib/dust-intl');

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   },
   "main": "index.js",
   "jsnext:main": "src/main.js",
+  "browser": {
+    "./lib/locales": false,
+    "./lib/locales.js": false
+  },
   "engines": {
     "node": ">=0.10.0",
     "npm": ">=1.4.0"

--- a/src/dust-intl.js
+++ b/src/dust-intl.js
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2014, Yahoo! Inc. All rights reserved.
+Copyrights licensed under the New BSD License.
+See the accompanying LICENSE file for terms.
+*/
+
+/* jshint esnext: true */
+
+import IntlMessageFormat from 'intl-messageformat';
+import IntlRelativeFormat from 'intl-relativeformat';
+
+import {registerWith} from './helpers.js';
+import defaultLocale from './en.js';
+
+export {registerWith};
+
+export function __addLocaleData(data) {
+    IntlMessageFormat.__addLocaleData(data);
+    IntlRelativeFormat.__addLocaleData(data);
+}
+
+__addLocaleData(defaultLocale);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -17,9 +17,9 @@ import {
     getFormatOptions,
     getLocales,
     tap
-} from './utils';
+} from './utils.js';
 
-export {registerWith, __addLocaleData};
+export {registerWith};
 
 // -----------------------------------------------------------------------------
 
@@ -60,11 +60,6 @@ function deprecate(name, suggestion) {
 
         return suggestion.apply(this, arguments);
     };
-}
-
-function __addLocaleData(data) {
-    IntlMessageFormat.__addLocaleData(data);
-    IntlRelativeFormat.__addLocaleData(data);
 }
 
 // -- Helpers ------------------------------------------------------------------

--- a/src/main.js
+++ b/src/main.js
@@ -6,10 +6,7 @@ See the accompanying LICENSE file for terms.
 
 /* jshint esnext: true */
 
-import {registerWith, __addLocaleData} from './helpers';
-import defaultLocale from './en';
-
-__addLocaleData(defaultLocale);
+import {registerWith, __addLocaleData} from './dust-intl.js';
 
 // Re-export as default for
 export default {


### PR DESCRIPTION
Update all `intl-*` dependencies and refactor this package to be more inline with how `react-intl` is structured.

The `"browser"` field has been added to the `package.json` to ignore all the locale data, expect English, when bundling with Browserify or Webpack.
