### PR TITLE
HTML-Escape helper output

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -45,209 +45,209 @@ function registerWith (dust) {
         intlNumber : deprecate('intlNumber', formatNumber),
         intlMessage: deprecate('intlMessage', formatMessage)
     });
-}
 
-function deprecate(name, suggestion) {
-    return function () {
-        if (typeof console !== 'undefined' &&
-            typeof console.warn === 'function') {
+    function deprecate(name, suggestion) {
+        return function () {
+            if (typeof console !== 'undefined' &&
+                typeof console.warn === 'function') {
 
-            console.warn(
-                '{@' + name + '} is deprecated, use: ' +
-                '{@' + suggestion.name + '}'
-            );
+                console.warn(
+                    '{@' + name + '} is deprecated, use: ' +
+                    '{@' + suggestion.name + '}'
+                );
+            }
+
+            return suggestion.apply(this, arguments);
+        };
+    }
+
+    // -- Helpers ------------------------------------------------------------------
+
+    /**
+    A block wrapper which stashes the `params` in the context so that
+    they are available for other intl helpers within the block.
+    @method intl
+    @param {Object} chunk The dust Chunk object.
+    @param {Object} context The dust Context object.
+    @param {Object} bodies An object containing the dust bodies.
+    @param {Object} params An object containing the parameters in the markup for this helper.
+    @return {Object} The `chunk` parameter.
+    */
+    function intl(chunk, context, bodies, params) {
+        var ctx = {};
+        if (bodies.block) {
+            ctx.intl = params || {};
+            return chunk.render(bodies.block, context.push(ctx));
         }
-
-        return suggestion.apply(this, arguments);
-    };
-}
-
-// -- Helpers ------------------------------------------------------------------
-
-/**
-A block wrapper which stashes the `params` in the context so that
-they are available for other intl helpers within the block.
-@method intl
-@param {Object} chunk The dust Chunk object.
-@param {Object} context The dust Context object.
-@param {Object} bodies An object containing the dust bodies.
-@param {Object} params An object containing the parameters in the markup for this helper.
-@return {Object} The `chunk` parameter.
-*/
-function intl(chunk, context, bodies, params) {
-    var ctx = {};
-    if (bodies.block) {
-        ctx.intl = params || {};
-        return chunk.render(bodies.block, context.push(ctx));
-    }
-    return chunk;
-}
-
-
-/**
-Interprets `params.val` as a date or time to format and uses the custom `date`
-formats.
-@method formatDate
-@param {Object} chunk The dust Chunk object.
-@param {Object} context The dust Context object.
-@param {Object} bodies An object containing the dust bodies.
-@param {Object} params An object containing the parameters in the markup for this helper.
-@return {Object} The `chunk` parameter.
-*/
-function formatDate(chunk, context, bodies, params) {
-    var formatOptions,
-        locales,
-        val,
-        formatter;
-    params = params || {};
-
-    if (!params.hasOwnProperty('val')) {
-        throw new ReferenceError('@formatDate needs a `val` parameter');
-    }
-    val = tap(params.val, chunk, context);
-    delete params.val;  // since params might be interpretted as format options
-    val = new Date(val);
-    assertIsDate(val, '@formatDate requires a valid date or timestamp `val`');
-
-    formatOptions = getFormatOptions('date', chunk, params, context);
-    locales = getLocales(chunk, params, context);
-    formatter = getDateTimeFormat(locales, formatOptions);
-    chunk.write(formatter.format(val));
-    return chunk;
-}
-
-
-/**
-Interprets `params.val` as a date or time to format and uses the custom `time`
-formats.
-@method formatTime
-@param {Object} chunk The dust Chunk object.
-@param {Object} context The dust Context object.
-@param {Object} bodies An object containing the dust bodies.
-@param {Object} params An object containing the parameters in the markup for this helper.
-@return {Object} The `chunk` parameter.
-*/
-function formatTime(chunk, context, bodies, params) {
-    var formatOptions,
-        locales,
-        val,
-        formatter;
-    params = params || {};
-
-    if (!params.hasOwnProperty('val')) {
-        throw new ReferenceError('@formatTime needs a `val` parameter');
-    }
-    val = tap(params.val, chunk, context);
-    delete params.val;  // since params might be interpretted as format options
-    val = new Date(val);
-    assertIsDate(val, '@formatTime requires a valid date or timestamp `val`');
-
-    formatOptions = getFormatOptions('time', chunk, params, context);
-    locales = getLocales(chunk, params, context);
-    formatter = getDateTimeFormat(locales, formatOptions);
-    chunk.write(formatter.format(val));
-    return chunk;
-}
-
-
-/**
-Interprets `params.val` as a date or time to format relative to "now", and uses
-the custom `relative` formats.
-@method formatRelative
-@param {Object} chunk The dust Chunk object.
-@param {Object} context The dust Context object.
-@param {Object} bodies An object containing the dust bodies.
-@param {Object} params An object containing the parameters in the markup for this helper.
-@return {Object} The `chunk` parameter.
-*/
-function formatRelative(chunk, context, bodies, params) {
-    var formatOptions,
-        locales,
-        val,
-        formatter;
-    params = params || {};
-
-    if (!params.hasOwnProperty('val')) {
-        throw new ReferenceError('@formatRelative needs a `val` parameter');
-    }
-    val = tap(params.val, chunk, context);
-    delete params.val;  // since params might be interpretted as format options
-    val = new Date(val);
-    assertIsDate(val, '@formatRelative requires a valid date or timestamp `val`');
-
-    formatOptions = getFormatOptions('relative', chunk, params, context);
-    locales = getLocales(chunk, params, context);
-    formatter = getRelativeFormat(locales, formatOptions);
-    chunk.write(formatter.format(val));
-    return chunk;
-}
-
-
-/**
-Interprets `params.val` as a number to format.
-@method formatNumber
-@param {Object} chunk The dust Chunk object.
-@param {Object} context The dust Context object.
-@param {Object} bodies An object containing the dust bodies.
-@param {Object} params An object containing the parameters in the markup for this helper.
-@return {Object} The `chunk` parameter.
-*/
-function formatNumber(chunk, context, bodies, params) {
-    var formatOptions,
-        locales,
-        val,
-        formatter;
-    params = params || {};
-
-    if (!params.hasOwnProperty('val')) {
-        throw new ReferenceError('@formatNumber needs a `val` parameter');
-    }
-    val = tap(params.val, chunk, context);
-    delete params.val;  // since params might be interpretted as format options
-
-    formatOptions = getFormatOptions('number', chunk, params, context);
-    locales = getLocales(chunk, params, context);
-    formatter = getNumberFormat(locales, formatOptions);
-    chunk.write(formatter.format(val));
-    return chunk;
-}
-
-
-/**
-Interprets `params.val` as a YRB message to format.
-@method formatMessage
-@param {Object} chunk The dust Chunk object.
-@param {Object} context The dust Context object.
-@param {Object} bodies An object containing the dust bodies.
-@param {Object} params An object containing the parameters in the markup for this helper.
-@return {Object} The `chunk` parameter.
-*/
-function formatMessage(chunk, context, bodies, params) {
-    var formatOptions = {},
-        locales,
-        msg,
-        formatter;
-    params = params || {};
-
-    if (params.hasOwnProperty('_msg')) {
-        msg = params._msg;
-    }
-    else if (params._key) {
-        msg = contextGet(context, ['intl', 'messages', tap(params._key, chunk, context)]);
-    }
-    else {
-        throw new ReferenceError('@formatMessage needs either a `_msg` or `_key` parameter');
-    }
-
-    // optimization for messages that have already been compiled
-    if ('object' === typeof msg && 'function' === typeof msg.format) {
-        chunk.write(msg.format(params));
         return chunk;
     }
 
-    formatOptions = contextGet(context, ['intl', 'formats']);
-    locales = getLocales(chunk, params, context);
-    formatter = getMessageFormat(msg, locales, formatOptions);
-    chunk.write(formatter.format(params));
-    return chunk;
+
+    /**
+    Interprets `params.val` as a date or time to format and uses the custom `date`
+    formats.
+    @method formatDate
+    @param {Object} chunk The dust Chunk object.
+    @param {Object} context The dust Context object.
+    @param {Object} bodies An object containing the dust bodies.
+    @param {Object} params An object containing the parameters in the markup for this helper.
+    @return {Object} The `chunk` parameter.
+    */
+    function formatDate(chunk, context, bodies, params) {
+        var formatOptions,
+            locales,
+            val,
+            formatter;
+        params = params || {};
+
+        if (!params.hasOwnProperty('val')) {
+            throw new ReferenceError('@formatDate needs a `val` parameter');
+        }
+        val = tap(params.val, chunk, context);
+        delete params.val;  // since params might be interpreted as format options
+        val = new Date(val);
+        assertIsDate(val, '@formatDate requires a valid date or timestamp `val`');
+
+        formatOptions = getFormatOptions('date', chunk, params, context);
+        locales = getLocales(chunk, params, context);
+        formatter = getDateTimeFormat(locales, formatOptions);
+        chunk.write(dust.escapeHtml(formatter.format(val)));
+        return chunk;
+    }
+
+
+    /**
+    Interprets `params.val` as a date or time to format and uses the custom `time`
+    formats.
+    @method formatTime
+    @param {Object} chunk The dust Chunk object.
+    @param {Object} context The dust Context object.
+    @param {Object} bodies An object containing the dust bodies.
+    @param {Object} params An object containing the parameters in the markup for this helper.
+    @return {Object} The `chunk` parameter.
+    */
+    function formatTime(chunk, context, bodies, params) {
+        var formatOptions,
+            locales,
+            val,
+            formatter;
+        params = params || {};
+
+        if (!params.hasOwnProperty('val')) {
+            throw new ReferenceError('@formatTime needs a `val` parameter');
+        }
+        val = tap(params.val, chunk, context);
+        delete params.val;  // since params might be interpretted as format options
+        val = new Date(val);
+        assertIsDate(val, '@formatTime requires a valid date or timestamp `val`');
+
+        formatOptions = getFormatOptions('time', chunk, params, context);
+        locales = getLocales(chunk, params, context);
+        formatter = getDateTimeFormat(locales, formatOptions);
+        chunk.write(dust.escapeHtml(formatter.format(val)));
+        return chunk;
+    }
+
+
+    /**
+    Interprets `params.val` as a date or time to format relative to "now", and uses
+    the custom `relative` formats.
+    @method formatRelative
+    @param {Object} chunk The dust Chunk object.
+    @param {Object} context The dust Context object.
+    @param {Object} bodies An object containing the dust bodies.
+    @param {Object} params An object containing the parameters in the markup for this helper.
+    @return {Object} The `chunk` parameter.
+    */
+    function formatRelative(chunk, context, bodies, params) {
+        var formatOptions,
+            locales,
+            val,
+            formatter;
+        params = params || {};
+
+        if (!params.hasOwnProperty('val')) {
+            throw new ReferenceError('@formatRelative needs a `val` parameter');
+        }
+        val = tap(params.val, chunk, context);
+        delete params.val;  // since params might be interpretted as format options
+        val = new Date(val);
+        assertIsDate(val, '@formatRelative requires a valid date or timestamp `val`');
+
+        formatOptions = getFormatOptions('relative', chunk, params, context);
+        locales = getLocales(chunk, params, context);
+        formatter = getRelativeFormat(locales, formatOptions);
+        chunk.write(dust.escapeHtml(formatter.format(val)));
+        return chunk;
+    }
+
+
+    /**
+    Interprets `params.val` as a number to format.
+    @method formatNumber
+    @param {Object} chunk The dust Chunk object.
+    @param {Object} context The dust Context object.
+    @param {Object} bodies An object containing the dust bodies.
+    @param {Object} params An object containing the parameters in the markup for this helper.
+    @return {Object} The `chunk` parameter.
+    */
+    function formatNumber(chunk, context, bodies, params) {
+        var formatOptions,
+            locales,
+            val,
+            formatter;
+        params = params || {};
+
+        if (!params.hasOwnProperty('val')) {
+            throw new ReferenceError('@formatNumber needs a `val` parameter');
+        }
+        val = tap(params.val, chunk, context);
+        delete params.val;  // since params might be interpretted as format options
+
+        formatOptions = getFormatOptions('number', chunk, params, context);
+        locales = getLocales(chunk, params, context);
+        formatter = getNumberFormat(locales, formatOptions);
+        chunk.write(dust.escapeHtml(formatter.format(val)));
+        return chunk;
+    }
+
+
+    /**
+    Interprets `params.val` as a YRB message to format.
+    @method formatMessage
+    @param {Object} chunk The dust Chunk object.
+    @param {Object} context The dust Context object.
+    @param {Object} bodies An object containing the dust bodies.
+    @param {Object} params An object containing the parameters in the markup for this helper.
+    @return {Object} The `chunk` parameter.
+    */
+    function formatMessage(chunk, context, bodies, params) {
+        var formatOptions = {},
+            locales,
+            msg,
+            formatter;
+        params = params || {};
+
+        if (params.hasOwnProperty('_msg')) {
+            msg = params._msg;
+        }
+        else if (params._key) {
+            msg = contextGet(context, ['intl', 'messages', tap(params._key, chunk, context)]);
+        }
+        else {
+            throw new ReferenceError('@formatMessage needs either a `_msg` or `_key` parameter');
+        }
+
+        // optimization for messages that have already been compiled
+        if ('object' === typeof msg && 'function' === typeof msg.format) {
+            chunk.write(msg.format(params));
+            return chunk;
+        }
+
+        formatOptions = contextGet(context, ['intl', 'formats']);
+        locales = getLocales(chunk, params, context);
+        formatter = getMessageFormat(msg, locales, formatOptions);
+        chunk.write(dust.escapeHtml(formatter.format(params)));
+        return chunk;
+    }
 }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -911,6 +911,21 @@ describe('Helper `formatMessage`', function () {
         });
     });
 
+    it('should return a escape HTML values', function (done) {
+        var tmpl = '{@formatMessage _msg=MSG name=name /}',
+            ctx = {
+                MSG: 'Hi, my name is {name}.',
+                name: '<b>Eric</b>'
+            },
+            expected = 'Hi, my name is &lt;b&gt;Eric&lt;/b&gt;';
+        dust.renderSource(tmpl, ctx, function (err, out) {
+            if (err) { return done(err); }
+
+            expect(out).to.equal(expected);
+            done();
+        });
+    });
+
     it('should return a formatted string with formatted numbers and dates', function (done) {
         var tmpl = '{@formatMessage _msg=POP_MSG locales="en-US" city=city population=population census_date=census_date timeZone=timeZone/}',
             ctx = {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -917,7 +917,7 @@ describe('Helper `formatMessage`', function () {
                 MSG: 'Hi, my name is {name}.',
                 name: '<b>Eric</b>'
             },
-            expected = 'Hi, my name is &lt;b&gt;Eric&lt;/b&gt;';
+            expected = 'Hi, my name is &lt;b&gt;Eric&lt;/b&gt;.';
         dust.renderSource(tmpl, ctx, function (err, out) {
             if (err) { return done(err); }
 


### PR DESCRIPTION
This **forces** each helper to HTML-escaping its output.

Fixes #50

_**Note:** This is mostly a formatting change, so it can be [viewed without seeing whitespace changes](https://github.com/yahoo/dust-intl/pull/51/files?w=1)._